### PR TITLE
Update firebase config files to use the appId provided during app creation

### DIFF
--- a/App_Resources/Android/google-services.json
+++ b/App_Resources/Android/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:33002893899:android:1aa8448c56b58a16",
         "android_client_info": {
-          "package_name": "org.nativescript.masterdetail"
+          "package_name": "__PACKAGE__"
         }
       },
       "oauth_client": [

--- a/App_Resources/iOS/GoogleService-Info.plist
+++ b/App_Resources/iOS/GoogleService-Info.plist
@@ -17,7 +17,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>org.nativescript.masterdetail</string>
+	<string>__PACKAGE__</string>
 	<key>PROJECT_ID</key>
 	<string>car-rental-b26b7</string>
 	<key>STORAGE_BUCKET</key>


### PR DESCRIPTION
1. Replace hardcoded `org.nativescript.masterdetail` package name / bundleId in google services files with `__PACKAGE__` placeholder
2. During postinstall replace the `__PACKAGE__` placeholder with the current appId of the created app (either auto-generated or specified with --appid parameter in tns create)

This somehow produces a runnable app with working firebase database (even if the resulting appId is not actually set up on the firebase server side). This is the only approach that actually results in an app that builds successfully and does not require specific appId upon app creation.

When this is merged it will be no longer required to pass --appid parameter when tns-creating this template.