### PR TITLE
Force iOS UISlider to work with discrete steps

### DIFF
--- a/cars/car-detail-edit/car-detail-edit.component.html
+++ b/cars/car-detail-edit/car-detail-edit.component.html
@@ -23,11 +23,11 @@
                 <Label col="1" horizontalAlignment="right" class="text-primary">
                     <FormattedString>
                         <Span text="€"></Span>
-                        <Span [text]="car.price"></Span>
+                        <Span [text]="pricePerDay"></Span>
                     </FormattedString>
                 </Label>
 
-                <Slider row="1" [(ngModel)]="car.price" colSpan="2"></Slider>
+                <Slider row="1" [(ngModel)]="pricePerDay" colSpan="2"></Slider>
 
                 <Label row="2" text="ADD OR REMOVE IMAGE" colSpan="2"></Label>
             </GridLayout>
@@ -72,11 +72,11 @@
                 <Label text="LUGGAGE"></Label>
                 <Label col="1" horizontalAlignment="right" class="text-primary">
                     <FormattedString>
-                        <Span [text]="car.luggage"></Span>
+                        <Span [text]="luggageValue"></Span>
                         <Span text=" Bag(s)"></Span>
                     </FormattedString>
                 </Label>
-                <Slider row="1" colSpan="2" minValue="0" maxValue="5" [(ngModel)]="car.luggage"></Slider>
+                <Slider row="1" colSpan="2" minValue="0" maxValue="5" [(ngModel)]="luggageValue"></Slider>
             </GridLayout>
 
         </StackLayout>

--- a/cars/car-detail-edit/car-detail-edit.component.ts
+++ b/cars/car-detail-edit/car-detail-edit.component.ts
@@ -68,6 +68,24 @@ export class CarDetailEditComponent implements OnInit {
         return this._car;
     }
 
+    get pricePerDay(): number {
+        return this._car.price;
+    }
+
+    set pricePerDay(value: number) {
+        // force iOS UISlider to work with discrete steps
+        this._car.price = Math.round(value);
+    }
+
+    get luggageValue(): number {
+        return this._car.luggage;
+    }
+
+    set luggageValue(value: number) {
+        // force iOS UISlider to work with discrete steps
+        this._car.luggage = Math.round(value);
+    }
+
     get carClasses(): Array<string> {
         return this._carClasses;
     }


### PR DESCRIPTION
Force iOS UISlider instances on "Edit" screen (luggage, price per day) to work with discrete steps as is the default behavior in Android (and expected behavior in this scenario).