### PR TITLE
Update pre/postinstall scripts to work with npm5

### DIFF
--- a/tools/preinstall.js
+++ b/tools/preinstall.js
@@ -1,26 +1,43 @@
 const fs = require("fs");
 const path = require("path");
+const exec = require("child_process").exec;
 
 console.log("preinstall script running...");
 
 const firebaseConfig = "firebase.nativescript.json";
-console.log(`creating ${firebaseConfig} to enable firebase...`);
-copyConfig(firebaseConfig);
-
 const tslintConfig = "tslint.json";
-console.log(`creating ${tslintConfig} to enable linting...`);
-copyConfig(tslintConfig);
 
-function copyConfig(configFilename) {
-    const oldPath = path.join(__dirname, configFilename);
-    const newPath = path.join(getAppRootFolder(), configFilename);
-    fs.rename(oldPath, newPath, (err) => {
-        if (err) {
-            console.error(err);
-        }
+getAppRootFolder()
+    .then((appRootFolder) => Promise.all([
+        copyConfig(firebaseConfig, appRootFolder),
+        copyConfig(tslintConfig, appRootFolder)
+    ]));
+
+function copyConfig(configFilename, appRootFolder) {
+    return new Promise((resolve, reject) => {
+        const sourcePath = path.join(__dirname, configFilename);
+        const destPath = path.join(appRootFolder, configFilename);
+
+        console.log(`creating ${path.resolve(destPath)}...`);
+        fs.rename(sourcePath, destPath, (err) => {
+            if (err) {
+                return reject(err);
+            }
+
+            resolve();
+        });
     });
 }
 
 function getAppRootFolder() {
-    return path.join("..", "..", "..");
+    return new Promise((resolve, reject) => {
+        // npm prefix returns the closest parent directory to contain a package.json file
+        exec("cd .. && npm prefix", (err, stdout) => {
+            if (err) {
+                return reject(err);
+            }
+
+            resolve(stdout.toString().trim());
+        });
+    });
 }


### PR DESCRIPTION
Reworked the logic for app root folder retrieval so now it works correctly with both npm 4 & 5 (tested with npm 4.2.0 (node 7.10.1) and npm 5.3.0 (node 8.2.1).

Now the logic relies on the `npm prefix` command that returns the closest parent directory to contain a package.json file. Btw I tested this approach when we implemented the pre/postinstall scripts in the first place but then it did not work correctly as package.json stub was still not available when we executed our postinstall script. Seems newer versions of tns CLI changed that particular behavior.

Also redesigned the scripts to use es6 promises.

http://teampulse.telerik.com/view#item/346248