### PR TITLE
Streamline edit custom components to use two-way data binding

### DIFF
--- a/cars/car-detail-edit/car-detail-edit.component.html
+++ b/cars/car-detail-edit/car-detail-edit.component.html
@@ -37,7 +37,7 @@
                 MyImageAddRemove is a custom component, that wraps an imagepicker plugin and provides custom design and logic
                 on top of it. Check out the custom component at /cars/car-detail-edit/my-image-add-remove.
                 -->
-                <MyImageAddRemove [imageUrl]="car.imageUrl" (selectionChanged)="onImageAddRemove($event)"></MyImageAddRemove>
+                <MyImageAddRemove [(imageUrl)]="carImageUrl"></MyImageAddRemove>
             </StackLayout>
 
             <Label class="car-list-odd" text="CLASS"></Label>
@@ -47,25 +47,25 @@
                 MyListSelector is a custom component, that provides custom design and logic for picking an option from a list.
                 Check out the custom component at /cars/car-detail-edit/my-list-selector.
                 -->
-                <MyListSelector [selectedValue]="car.class" [items]="carClassOptions" tag="class"></MyListSelector>
+                <MyListSelector [(selectedValue)]="car.class" [items]="carClassOptions" tag="class"></MyListSelector>
             </StackLayout>
 
             <Label class="car-list-odd" text="DOORS"></Label>
 
             <StackLayout class="car-list-even">
-                <MyListSelector [selectedValue]="car.doors" [items]="carDoorOptions" tag="doors"></MyListSelector>
+                <MyListSelector [(selectedValue)]="car.doors" [items]="carDoorOptions" tag="doors"></MyListSelector>
             </StackLayout>
 
             <Label class="car-list-odd" text="SEATS"></Label>
 
             <StackLayout class="car-list-even">
-                <MyListSelector [selectedValue]="car.seats" [items]="carSeatOptions" tag="seats"></MyListSelector>
+                <MyListSelector [(selectedValue)]="car.seats" [items]="carSeatOptions" tag="seats"></MyListSelector>
             </StackLayout>
 
             <Label class="car-list-odd" text="TRANSMISSION"></Label>
 
             <StackLayout class="car-list-even">
-                <MyListSelector [selectedValue]="car.transmission" [items]="carTransmissionOptions" tag="transmission"></MyListSelector>
+                <MyListSelector [(selectedValue)]="car.transmission" [items]="carTransmissionOptions" tag="transmission"></MyListSelector>
             </StackLayout>
 
             <GridLayout rows="*, 55" columns="auto, *" class="car-list-odd">

--- a/cars/car-detail-edit/car-detail-edit.component.ts
+++ b/cars/car-detail-edit/car-detail-edit.component.ts
@@ -24,7 +24,6 @@ export class CarDetailEditComponent implements OnInit {
     private _carDoorOptions: Array<number> = [];
     private _carSeatOptions: Array<string> = [];
     private _carTransmissionOptions: Array<string> = [];
-    private _carImageUriToUpload: string = null;
     private _isCarImageDirty: boolean = false;
     private _isUpdating: boolean = false;
 
@@ -100,8 +99,13 @@ export class CarDetailEditComponent implements OnInit {
         return this._carTransmissionOptions;
     }
 
-    set carLuggageValue(value: number) {
-        this._car.luggage = value;
+    get carImageUrl(): string {
+        return this._car.imageUrl;
+    }
+
+    set carImageUrl(value: string) {
+        this._car.imageUrl = value;
+        this._isCarImageDirty = true;
     }
 
     /* ***********************************************************
@@ -127,13 +131,9 @@ export class CarDetailEditComponent implements OnInit {
 
         this._isUpdating = true;
 
-        if (this._isCarImageDirty && this._carImageUriToUpload) {
+        if (this._isCarImageDirty && this._car.imageUrl) {
             queue = queue
-                .then(() =>
-                    this._carService.uploadImage(this._car.imageStoragePath, this._carImageUriToUpload))
-                .then((uploadedFile: any) => {
-                    this._car.imageUrl = uploadedFile.url;
-                });
+                .then(() => this._carService.uploadImage(this._car.imageStoragePath, this._car.imageUrl));
         }
 
         queue.then(() => this._carService.update(this._car))
@@ -170,13 +170,6 @@ export class CarDetailEditComponent implements OnInit {
                     curve: "ease"
                 }
             }));
-    }
-
-    onImageAddRemove(args): void {
-        if (args.newValue) {
-            this._isCarImageDirty = true;
-            this._carImageUriToUpload = args.newValue;
-        }
     }
 
     private initializeEditOptions(): void {

--- a/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
+++ b/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
@@ -15,7 +15,7 @@ import * as platform from "tns-core-modules/platform";
 })
 export class MyImageAddRemoveComponent {
     @Input() imageUrl: string = "";
-    @Output() selectionChanged: EventEmitter<any> = new EventEmitter();
+    @Output() imageUrlChange = new EventEmitter<string>();
 
     onImageAddRemoveTap(): void {
         if (this.imageUrl) {
@@ -60,6 +60,6 @@ export class MyImageAddRemoveComponent {
         }
 
         this.imageUrl = newValue;
-        this.selectionChanged.emit({ oldValue, newValue });
+        this.imageUrlChange.emit(this.imageUrl);
     }
 }

--- a/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
+++ b/cars/car-detail-edit/my-list-selector/my-list-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewContainerRef } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output, ViewContainerRef } from "@angular/core";
 import { ModalDialogOptions, ModalDialogService } from "nativescript-angular/modal-dialog";
 import { PageRoute } from "nativescript-angular/router";
 
@@ -21,9 +21,10 @@ const capitalizeFirstLetter = (s) => s.charAt(0).toUpperCase() + s.slice(1);
     templateUrl: "./my-list-selector.component.html"
 })
 export class MyListSelectorComponent implements OnInit {
-    @Input() selectedValue: string;
-    @Input() items: Array<string>;
     @Input() tag: string;
+    @Input() items: Array<string>;
+    @Input() selectedValue: string;
+    @Output() selectedValueChange = new EventEmitter<string>();
 
     private _carEditModel: Car;
 
@@ -62,7 +63,8 @@ export class MyListSelectorComponent implements OnInit {
         this._modalService.showModal(MyListSelectorModalViewComponent, options)
             .then((selectedValue: string) => {
                 if (selectedValue) {
-                    this._carEditModel[this.tag] = selectedValue;
+                    this.selectedValue = selectedValue;
+                    this.selectedValueChange.emit(this.selectedValue);
                 }
             });
     }


### PR DESCRIPTION
Streamlined the implementation of the "edit" custom components (MyListSelector and MyImageAddRemove) to use [two-way data binding](https://nativescript.github.io/workshop/#chapter5.8) instead of the current mixture of bound values, manual updates, and event emitters.

http://teampulse.telerik.com/view#item/346290
