### PR TITLE
Clean up code with imagepicker plugin update

### DIFF
--- a/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
+++ b/cars/car-detail-edit/my-image-add-remove/my-image-add-remove.component.ts
@@ -1,7 +1,5 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import * as imagePicker from "nativescript-imagepicker";
-import * as permissions from "nativescript-permissions";
-import * as platform from "tns-core-modules/platform";
 
 /* ***********************************************************
 * The MyImageAddRemove custom component uses an imagepicker plugin to let the user select
@@ -28,23 +26,12 @@ export class MyImageAddRemoveComponent {
             mode: "single"
         });
 
-        let queue = Promise.resolve();
-
-        // lower SDK versions will grant permission from AndroidManifest file
-        if (platform.device.os === "Android" && Number(platform.device.sdkVersion) >= 23) {
-            queue = queue.then(() => permissions.requestPermission("android.permission.READ_EXTERNAL_STORAGE"));
-        }
-
-        queue.then(() => this.startSelection(context))
-            .catch((errorMessage: any) => console.log(errorMessage));
-    }
-
-    startSelection(context): void {
         context
             .authorize()
             .then(() => context.present())
-            .then((selection) => selection.forEach((selectedImage) => this.handleImageChange(selectedImage.fileUri)))
-            .catch((errorMessage: any) => console.log(errorMessage));
+            .then((selection) => selection.forEach(
+                (selectedImage) => this.handleImageChange(selectedImage.fileUri))
+            ).catch((errorMessage: any) => console.log(errorMessage));
     }
 
     handleImageChange(newValue): void {

--- a/cars/shared/car.service.ts
+++ b/cars/shared/car.service.ts
@@ -79,8 +79,7 @@ export class CarService {
         if (data) {
             for (const id in data) {
                 if (data.hasOwnProperty(id)) {
-                    const result = Object.assign({ id }, ...data[id]);
-                    this._cars.push(new Car(result));
+                    this._cars.push(new Car(data[id]));
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "@angular/platform-browser": "~4.1.0",
     "@angular/router": "~4.1.0",
     "nativescript-angular": "~3.1.0",
-    "nativescript-imagepicker": "^3.0.1",
-    "nativescript-permissions": "^1.2.3",
+    "nativescript-imagepicker": "~3.0.3",
     "nativescript-plugin-firebase": "^3.11.4",
     "nativescript-telerik-ui": "^3.0.0",
     "nativescript-theme-core": "~1.0.2",
@@ -48,4 +47,3 @@
     "postinstall": "node tools/postinstall.js"
   }
 }
-


### PR DESCRIPTION
Latest version 3.0.3 of nativescript-imagepicker plugin incorporates the logic for Android 6 & 7 permissions https://github.com/NativeScript/nativescript-imagepicker/issues/66 so we can remove it from our code.