### PR TITLE
Fix image-picking functionality on iOS physical device

### DIFF
--- a/cars/car-detail-edit/car-detail-edit.component.html
+++ b/cars/car-detail-edit/car-detail-edit.component.html
@@ -10,7 +10,7 @@
     </ActionItem>
 </ActionBar>
 
-<GridLayout class="page page-content" >
+<GridLayout class="page page-content">
     <ScrollView>
         <StackLayout class="car-list">
 


### PR DESCRIPTION
Fixed broken image-picking functionality on iOS [physical] device -- image was displayed neither as a thumbnail, nor was it uploaded correctly to firebase.

In order to fix this we are now creating a temporary copy of the selected image within an app-relative folder. Also, we are scaling down this image to a maxHeight of 768 pixels (this applies to both iOS and Android).

http://teampulse.telerik.com/view#item/346952