### PR TITLE
Update nativescript-dev-typescript to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "codelyzer": "3.2.0",
     "nativescript-dev-sass": "1.3.2",
-    "nativescript-dev-typescript": "0.5.0",
+    "nativescript-dev-typescript": "0.5.1",
     "node-sass": "4.5.3",
     "tslint": "5.7.0",
     "typescript": "2.5.2"


### PR DESCRIPTION
Per tooling team's request.

https://github.com/NativeScript/nativescript-dev-typescript/releases/tag/v0.5.1
https://github.com/NativeScript/nativescript-dev-typescript/commit/0a725d7fc38ae6703aa15bb5313f1a33b27fa002