### PR TITLE
chor: update tns core modules version for Sidekick

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nativescript-theme-core": "1.0.4",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.5.2",
-    "tns-core-modules": "3.3.0",
+    "tns-core-modules": "3.4.0",
     "zone.js": "0.8.18"
   },
   "devDependencies": {


### PR DESCRIPTION
We need to release a new version of {N} Sidekick asap so we are releasing templates@3.4.0 with updated tns core modules 3.4.0 only. We will be releasing templates@3.4.1 soon afterwards that will enable webpack builds, Angular 5 support, etc from the ns-3.4 branch.